### PR TITLE
fix: increment file counter during processing for real-time stats

### DIFF
--- a/vam_tools/analysis/scanner.py
+++ b/vam_tools/analysis/scanner.py
@@ -251,6 +251,15 @@ class ImageScanner:
                                 self.catalog.add_image(image)
                                 self.files_added += 1
 
+                                # Update real-time performance counters
+                                if self.perf_tracker:
+                                    self.perf_tracker.metrics.total_files_analyzed = (
+                                        self.files_added
+                                    )
+                                    self.perf_tracker.metrics.bytes_processed += (
+                                        file_size
+                                    )
+
                                 # Generate thumbnail if enabled
                                 if self.generate_thumbnails:
                                     thumb_path = get_thumbnail_path(


### PR DESCRIPTION
## Summary
Fixes the Statistics tab showing 0 files processed during analysis by incrementing performance counters in real-time as files are processed.

## Problem
The `ImageScanner` was only setting `total_files_analyzed` once at the end of scanning. The performance callback writes to the catalog every 5 seconds, but the counter never changed during the scan, so the Statistics tab would show:
- 0 files processed
- 0.0 files/second throughput  
- "Analysis in Progress" banner but no actual progress

## Solution
Modified the scanner to increment performance counters after each file is added:
- `perf_tracker.metrics.total_files_analyzed` incremented after each file
- `perf_tracker.metrics.bytes_processed` incremented after each file

Now the every-5-second performance callback has updated values to write to the catalog, enabling real-time progress visibility.

## Changes
- `vam_tools/analysis/scanner.py`: Added real-time counter updates in processing loop (lines 254-261)

## Testing
- ✅ All 562 tests passing (including 16 scanner tests)
- ✅ Code formatting, linting, and type checks passing
- ✅ 77% overall code coverage, 82% scanner coverage

## Impact
The Statistics tab will now display live progress during analysis:
- Files processed counter incrementing in real-time
- Throughput (files/sec) updating every second
- Data processed (bytes) increasing as files are scanned
- Real-time charts animating with actual data instead of zeros

🤖 Generated with [Claude Code](https://claude.com/claude-code)